### PR TITLE
problem: users can't easily pick out the store name in the store list

### DIFF
--- a/imports/ui/nearme.jsx
+++ b/imports/ui/nearme.jsx
@@ -152,23 +152,18 @@ function getClientLocation() {
     var updateNumber = 0;
       return (
           <Card key={location._id} style={{backgroundColor:"white"}}>
-              <ListItem modifier="nodivider">
+              <ListItem style={{fontSize: 20, fontWeight: "bold"}} modifier="nodivider">
                   {location.name}
+                  <div className="right">
+                      <Button onClick={() => {
+                          history.push('/duplicated?id=' + location._id)
+                      }}>
+                          <i className="fas fa-exclamation-triangle"/>
+                      </Button>
+                  </div>
               </ListItem>
               <ListItem modifier="nodivider">
                   {location.address}
-                  <div className="right">
-                  <Button onClick={()=>{history.push('/duplicated?id='+location._id)}}>
-                   <i className="fas fa-exclamation-triangle"></i>
-                 </Button>
-                 </div>
-                  {/*<div className="right">
-                       }<Button
-                      onClick={() => {
-                          history.push('/shopDetails?id=' + location._id)
-                      }}
-                  >More Details</Button>
-                  </div> */}
               </ListItem>
               <ListItem modifier="nodivider">
                   <div className="center" style={{color:Indicator}}>


### PR DESCRIPTION
solution: give the store name more emphasis - bold and a bigger font.
Also move the report duplicate button in line with the title - this
has the effect that there is more whitespace around the title, where
previously this was around the address.