### PR TITLE
problem: confirm button doesn't work

### DIFF
--- a/imports/ui/nearme.jsx
+++ b/imports/ui/nearme.jsx
@@ -149,7 +149,7 @@ function getClientLocation() {
           Indicator = "red"
           break
     }
-    var updateNumber = 0;
+    var updateNumber = location.line;
       return (
           <Card key={location._id} style={{backgroundColor:"white"}}>
               <ListItem style={{fontSize: 20, fontWeight: "bold"}} modifier="nodivider">


### PR DESCRIPTION
When the user hasn't moved the slider and just clicks 'confirm', the
store is updated to have a queue of 0.

solution: initialise the update number to the current line length
instead of 0.