### PR TITLE
problem: social media share buttons aren't properly responsive on small screens

### DIFF
--- a/imports/ui/nearme.jsx
+++ b/imports/ui/nearme.jsx
@@ -237,7 +237,7 @@ function Index({ history }) {
                     <div className="right">
                     </div>
                 </ListItem>
-                <ListItem modifier="nodivider">
+                <ListItem modifier="nodivider" style={{ flexWrap: 'wrap' }}>
                     <div className="center">
                         <Button id={location._id} onClick={
                             function (event) {


### PR DESCRIPTION
solution: apply flex-wrap: wrap to the list item containing the update button and social media icons

Fixes  howlongistheline/howlongistheline.org#167